### PR TITLE
Update plugin for Elasticsearch 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<elasticsearch.version>1.5.0</elasticsearch.version>
+		<elasticsearch.version>2.4.4</elasticsearch.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<developers>
@@ -119,7 +121,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.7</version>
+                  <version>${maven.compiler.target}</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -131,10 +133,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -16,4 +16,14 @@
             </excludes>
         </dependencySet>
     </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources/</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.properties</include>
+            </includes>
+            <filtered>true</filtered>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/src/main/java/org/elasticsearch/index/analysis/SkroutzGreekStemmer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SkroutzGreekStemmer.java
@@ -3,7 +3,6 @@ package org.elasticsearch.index.analysis;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Arrays;
 import java.util.List;
@@ -11,10 +10,14 @@ import java.util.List;
 import org.apache.lucene.analysis.el.GreekLowerCaseFilter;
 import org.apache.lucene.analysis.util.CharArrayMap;
 import org.apache.lucene.analysis.util.CharArraySet;
+
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.lucene.Lucene;
 import org.yaml.snakeyaml.Yaml;
+
+import org.apache.lucene.analysis.util.WordlistLoader;
+import org.apache.lucene.util.IOUtils;
+
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -73,7 +76,7 @@ public class SkroutzGreekStemmer {
       this.protectedWords = loadProtected("protected_words");
       this.stepZeroExceptions = loadExceptions("step_0_exceptions");
     } catch(IOException ex) {
-        logger.warn("Failed to load exceptions from yaml file");
+      logger.warn("Failed to load exceptions from yaml file");
     }
   }
 
@@ -278,7 +281,7 @@ public class SkroutzGreekStemmer {
    * <p>
    * <i>παρεα - παρεασ - παρεεσ, στερεα - στερεασ - στερεεσ</i>
    */
-  private static final CharArraySet exc4 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc4 = new CharArraySet(
       Arrays.asList("θ", "δ", "ελ", "γαλ", "ν", "π", "ιδ", "παρ", "στερ",
           "ορφ", "ανδρ", "αντρ"),
       false);
@@ -313,7 +316,7 @@ public class SkroutzGreekStemmer {
    * πατριος - πατρα, ποντος - ποντιος, σκορπω - σκορπιος, σπανιος - σπανος,
    * τιμή - τιμιος</i>
    */
-  private static final CharArraySet exc5 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc5 = new CharArraySet(
       Arrays.asList("αγ", "αγγελ", "αγρ", "αερ", "αθλ", "ακουσ", "αξ", "ασ",
           "β", "βιβλ", "βυτ", "γ", "γιαγ", "γων", "δ", "δαν", "δηλ", "δημ",
           "δοκιμ", "ελ", "ζαχαρ", "ηλ", "ηπ", "ιδ", "ισκ", "ιστ", "ιον",  "ιων",
@@ -375,7 +378,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc6 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc6 = new CharArraySet(
       Arrays.asList("αδ", "αλ", "αμαν", "αμερ", "αμμοχαλ", "ανηθ", "αντιδ",
           "απλ", "αττ", "αφρ", "βασ", "βρωμ","βρωμ", "γεν", "γερ", "δ", "δικαν",
           "δυτ", "ειδ", "ενδ", "εξωδ", "ηθ", "θετ", "καλλιν", "καλπ", "καταδ",
@@ -418,7 +421,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc7 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc7 = new CharArraySet(
       Arrays.asList("αναπ", "αποθ", "αποκ", "αποστ", "βουβ", "ξεθ", "ουλ",
           "πεθ", "πικρ", "ποτ", "σιχ", "χ"),
       false);
@@ -445,11 +448,11 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc8a = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc8a = new CharArraySet(
       Arrays.asList("τρ", "τσ"),
       false);
 
-  private static final CharArraySet exc8b = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc8b = new CharArraySet(
       Arrays.asList("βετερ", "βουλκ", "βραχμ", "γ", "δραδουμ", "θ", "καλπουζ",
           "καστελ", "κορμορ", "λαοπλ", "μωαμεθ", "μ", "μουσουλμ", "ν", "ουλ",
           "π", "πελεκ", "πλ", "πολισ", "πορτολ", "σαρακατσ", "σουλτ",
@@ -508,7 +511,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc9 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc9 = new CharArraySet(
       Arrays.asList("αβαρ", "βεν", "εναρ", "αβρ", "αδ", "αθ", "αν", "απλ",
           "βαρον", "ντρ", "σκ", "κοπ", "μπορ", "νιφ", "παγ", "παρακαλ", "σερπ",
           "σκελ", "συρφ", "τοκ", "υ", "δ", "εμ", "θαρρ", "θ"),
@@ -596,11 +599,11 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc12a = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc12a = new CharArraySet(
       Arrays.asList("π", "απ", "συμπ", "ασυμπ", "ακαταπ", "αμεταμφ"),
       false);
 
-  private static final CharArraySet exc12b = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc12b = new CharArraySet(
       Arrays.asList("αλ", "αρ", "εκτελ", "ζ", "μ", "ξ", "παρακαλ", "αρ", "προ", "νισ"),
       false);
 
@@ -620,7 +623,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc13 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc13 = new CharArraySet(
       Arrays.asList("διαθ", "θ", "παρακαταθ", "προσθ", "συνθ"),
       false);
 
@@ -654,7 +657,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc14 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc14 = new CharArraySet(
       Arrays.asList("φαρμακ", "χαδ", "αγκ", "αναρρ", "βρομ", "εκλιπ", "λαμπιδ",
           "λεχ", "μ", "πατ", "ρ", "λ", "μεδ", "μεσαζ", "υποτειν", "αμ", "αιθ",
           "ανηκ", "δεσποζ", "ενδιαφερ", "δε", "δευτερευ", "καθαρευ", "πλε",
@@ -692,7 +695,7 @@ public class SkroutzGreekStemmer {
    return len;
   }
 
-  private static final CharArraySet exc15a = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc15a = new CharArraySet(
       Arrays.asList("αβαστ", "πολυφ", "αδηφ", "παμφ", "ρ", "ασπ", "αφ", "αμαλ",
           "αμαλλι", "ανυστ", "απερ", "ασπαρ", "αχαρ", "δερβεν", "δροσοπ",
           "ξεφ", "νεοπ", "νομοτ", "ολοπ", "ομοτ", "προστ", "προσωποπ", "συμπ",
@@ -701,7 +704,7 @@ public class SkroutzGreekStemmer {
           "ουλαμ", "ουρ", "π", "τρ", "μ"),
       false);
 
-  private static final CharArraySet exc15b = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc15b = new CharArraySet(
       Arrays.asList("ψοφ", "ναυλοχ"),
       false);
 
@@ -738,7 +741,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc16 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc16 = new CharArraySet(
       Arrays.asList("ν", "χερσον", "δωδεκαν", "ερημον", "μεγαλον", "επταν", "ι"),
       false);
 
@@ -758,7 +761,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc17 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc17 = new CharArraySet(
       Arrays.asList("ασβ", "σβ", "αχρ", "χρ", "απλ", "αειμν", "δυσχρ", "ευχρ", "κοινοχρ", "παλιμψ"),
       false);
 
@@ -772,7 +775,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc18 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc18 = new CharArraySet(
       Arrays.asList("ν", "ρ", "σπι", "στραβομουτσ", "κακομουτσ", "εξων"),
       false);
 
@@ -796,7 +799,7 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc19 = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc19 = new CharArraySet(
       Arrays.asList("παρασουσ", "φ", "χ", "ωριοπλ", "αζ", "αλλοσουσ", "ασουσ"),
       false);
 
@@ -820,10 +823,10 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc20a = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc20a = new CharArraySet(
       Arrays.asList("γραμμ"), false);
 
-  private static final CharArraySet exc20b = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc20b = new CharArraySet(
       Arrays.asList("γεμ", "σταμ"), false);
 
 
@@ -969,10 +972,10 @@ public class SkroutzGreekStemmer {
     return len;
   }
 
-  private static final CharArraySet exc23a = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc23a = new CharArraySet(
       Arrays.asList("εξ", "εσ", "κατ", "αν", "κ", "μ", "πρ"), false);
 
-  private static final CharArraySet exc23b = new CharArraySet(Lucene.VERSION,
+  private static final CharArraySet exc23b = new CharArraySet(
       Arrays.asList("κα", "μ", "λε", "ελε", "δε"), false);
 
 

--- a/src/main/java/org/elasticsearch/index/analysis/SkroutzGreekStemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/SkroutzGreekStemmerTokenFilterFactory.java
@@ -3,22 +3,23 @@ package org.elasticsearch.index.analysis;
 import java.io.IOException;
 
 import org.apache.lucene.analysis.TokenStream;
+
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.settings.IndexSettingsService;
 
 public class SkroutzGreekStemmerTokenFilterFactory extends
 		AbstractTokenFilterFactory {
 
 	@Inject
 	public SkroutzGreekStemmerTokenFilterFactory(Index index,
-			@IndexSettings Settings indexSettings,
+			IndexSettingsService indexSettings,
 			Environment env, @Assisted String name,
 			@Assisted Settings settings) throws IOException {
-		super(index, indexSettings, name, settings);
+		super(index, indexSettings.getSettings(), name, settings);
 	}
 
 	@Override

--- a/src/main/java/org/elasticsearch/plugin/analysis/skroutzgreekstemmer/SkroutzGreekStemmerPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/analysis/skroutzgreekstemmer/SkroutzGreekStemmerPlugin.java
@@ -1,10 +1,10 @@
 package org.elasticsearch.plugin.analysis.skroutzgreekstemmer;
 
-import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.index.analysis.AnalysisModule;
 import org.elasticsearch.index.analysis.SkroutzGreekStemmerBinderProcessor;
 
-public class SkroutzGreekStemmerPlugin extends AbstractPlugin {
+public class SkroutzGreekStemmerPlugin extends Plugin {
 
 	@Override
 	public String description() {

--- a/src/main/resources/es-plugin.properties
+++ b/src/main/resources/es-plugin.properties
@@ -1,2 +1,0 @@
-plugin=org.elasticsearch.plugin.analysis.skroutzgreekstemmer.SkroutzGreekStemmerPlugin
-version=${project.version}

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,8 @@
+name=${project.name}
+description=${project.description}
+version=${project.version}
+
+jvm=true
+java.version=${maven.compiler.target}
+elasticsearch.version=${elasticsearch.version}
+classname=org.elasticsearch.plugin.analysis.skroutzgreekstemmer.SkroutzGreekStemmerPlugin

--- a/src/test/java/org/elasticsearch/index/analysis/SimpleSkroutzGreekStemmerAnalysisTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SimpleSkroutzGreekStemmerAnalysisTest.java
@@ -13,10 +13,9 @@ import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNameModule;
 import org.elasticsearch.index.settings.IndexSettingsModule;
-import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class SimpleSkroutzGreekStemmerAnalysisTest {
@@ -26,12 +25,14 @@ public class SimpleSkroutzGreekStemmerAnalysisTest {
       Index index = new Index("test");
 
       Settings indexSettings = settingsBuilder()
-          .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+          .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+          .put("path.home", "/")
+          .build();
 
       Injector parentInjector = new ModulesBuilder()
           .add(new SettingsModule(indexSettings),
-               new EnvironmentModule(new Environment(indexSettings)),
-               new IndicesAnalysisModule()).createInjector();
+               new EnvironmentModule(new Environment(indexSettings)))
+	  .createInjector();
 
       Injector injector = new ModulesBuilder()
           .add(new IndexSettingsModule(index, indexSettings),


### PR DESCRIPTION
And I mean exactly **`2.4.4`**, since the version of Elasticsearch we specify in `plugin-descriptor.properties` [must match exactly the current running version](https://github.com/elastic/elasticsearch/blob/v2.3.2/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java#L117) and the [minor version cannot be wildcarded](https://github.com/elastic/elasticsearch/blob/v2.3.2/core/src/main/java/org/elasticsearch/Version.java#L604).

Resolves #9 

The reason for this branch is that we might need this step in production before upgrading directly to 5.x.x series, but it's also easier to upgrade the plugin in steps.

Right now the latest stable elasticsearch version in the 2.x.x series is 2.4.4 (lucene 5.5.2).
Also note that java 8 is required (up from 7).