### PR TITLE
Run plugin tests from Docker

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,7 @@
+FROM maven:3-jdk-8
+
+ADD . /elasticsearch-skroutz-greekstemmer
+
+WORKDIR /elasticsearch-skroutz-greekstemmer
+
+ENTRYPOINT ["mvn", "install"]


### PR DESCRIPTION
We are adding Docker support since we need to add the plugins into Jenkins.