### PR TITLE
Bump log4j version to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 			<scope>compile</scope>
 		</dependency>
 
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Bump log4j-api & log4j-core to version 2.17.0 witch is pached for
[CVE-2021-45105](https://www.cve.org/CVERecord?id=CVE-2021-45105)