### PR TITLE
Bump Elasticsearch to 9.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gr.skroutz</groupId>
 	<artifactId>elasticsearch-skroutz-greekstemmer</artifactId>
-	<version>9.3.3.1-SNAPSHOT</version>
+	<version>9.4.0.1-SNAPSHOT</version>
 	<description>Greek stemmer for ElasticSearch</description>
 	<inceptionYear>2012</inceptionYear>
 
@@ -18,7 +18,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<elasticsearch.version>9.3.3</elasticsearch.version>
+		<elasticsearch.version>9.4.0</elasticsearch.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
 	</properties>


### PR DESCRIPTION
This commit bumps Elasticsearch to 9.4.0.